### PR TITLE
uncomment imklog in /etc/rsyslog.conf

### DIFF
--- a/start-sshd.sh
+++ b/start-sshd.sh
@@ -10,6 +10,10 @@ echo ocrd:x:$UID:$GID:SSH user:/:/bin/bash >> /etc/passwd
 echo ocrd:*:19020:0:99999:7::: >> /etc/shadow
 #/usr/sbin/sshd -D -e
 service ssh start
+
+# Replace imklog to prevent starting problems of rsyslog
+/bin/sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+
 service rsyslog start
 sleep 1
 tail -f /var/log/syslog


### PR DESCRIPTION
run into problem when starting rsyslog in start-sshd.sh

```
rsyslogd: imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.
```

https://stackoverflow.com/questions/56609182/openthread-environment-docker-rsyslogd-imklog-cannot-open-kernel-log-proc-km