### PR TITLE
Create publish gh workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish OCR-D Controller
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY_PATH: ghcr.io/bertsky
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - # Activate cache export feature to reduce build time of images
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Build the OCR-D Controller image and deploy to GitHub Container Repository
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: ${{ env.REGISTRY_PATH }}/ocrd_controller:latest
+        build-args: |
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          VCS_REF=$(git rev-parse --short HEAD)
+        cache-from: type=gha
+        cache-to: type=gha,mode=max  
+    


### PR DESCRIPTION
* GitHub workflow builds the docker image of OCR-D Controller with name `ghcr.io/bertsky/ocrd_controller:latest` using the GitHub Actions Cache
* Deploy the image to the GitHub Container Repository