### PR TITLE
Avoid error message because of existing directory

### DIFF
--- a/start-sshd.sh
+++ b/start-sshd.sh
@@ -3,7 +3,7 @@
 # copy the mounted credentials into the user dir
 cat /authorized_keys >> /.ssh/authorized_keys
 
-mkdir $TESSDATA_PREFIX
+mkdir -p $TESSDATA_PREFIX
 ln -t $TESSDATA_PREFIX /usr/local/share/tessdata/*.traineddata
 
 # silence the greeting


### PR DESCRIPTION
Restarting of a Docker container shows an error because a directory already exists:

    ocrd_kitodo-ocrd-controller-1  | mkdir: cannot create directory ‘/models/ocrd-resources/ocrd-tesserocr-recognize’: File exists

Signed-off-by: Stefan Weil <sw@weilnetz.de>