### PR TITLE
Avoid error messages because of hard links

### DIFF
--- a/start-sshd.sh
+++ b/start-sshd.sh
@@ -4,7 +4,7 @@
 cat /authorized_keys >> /.ssh/authorized_keys
 
 mkdir -p $TESSDATA_PREFIX
-ln -t $TESSDATA_PREFIX /usr/local/share/tessdata/*.traineddata
+ln -sf /usr/local/share/tessdata/*.traineddata $TESSDATA_PREFIX
 
 # silence the greeting
 touch /.hushlogin

--- a/start-sshd.sh
+++ b/start-sshd.sh
@@ -4,7 +4,7 @@
 cat /authorized_keys >> /.ssh/authorized_keys
 
 mkdir -p $TESSDATA_PREFIX
-ln -sf /usr/local/share/tessdata/*.traineddata $TESSDATA_PREFIX
+cp /usr/local/share/tessdata/*.traineddata $TESSDATA_PREFIX/
 
 # silence the greeting
 touch /.hushlogin


### PR DESCRIPTION
Starting of a Docker container can show an error because creating hard links is not possible across filesystems:

    ln: failed to create hard link '/models/ocrd-resources/ocrd-tesserocr-recognize/eng.traineddata' => '/usr/local/share/tessdata/eng.traineddata': Invalid cross-device link
    ln: failed to create hard link '/models/ocrd-resources/ocrd-tesserocr-recognize/equ.traineddata' => '/usr/local/share/tessdata/equ.traineddata': Invalid cross-device link
    ln: failed to create hard link '/models/ocrd-resources/ocrd-tesserocr-recognize/osd.traineddata' => '/usr/local/share/tessdata/osd.traineddata': Invalid cross-device link

In addition, restarting an existing Docker container will always give an error because the hard links already exist.

Using forced symbolic links fixes both kinds of errors.

Signed-off-by: Stefan Weil <sw@weilnetz.de>