### PR TITLE
docker-compose.yml: set device count: all explicitly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,5 @@ services:
             # but the semantics of "count" is _at least_ unfortunately
             # (which would fail on CPU-only systems), so just leave unspecified
             #  count: 1
+            # update: default count:all does not work anymore, so make explicit
+              count: all


### PR DESCRIPTION
Note: this became necessary due to some regression (either in Docker engine or Compose plugin). The documented default does not work anymore, so here we must set it explicitly.